### PR TITLE
migrate to laminas-permissions-acl

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,5 @@
         "psr-4":{
             "Ray\\RoleModule\\": ["tests/", "tests/Fake"]
         }
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     ],
     "license": "MIT",
     "require": {
-        "zendframework/zend-permissions-acl": "~2.5",
-        "ray/di": "~2.0"
+        "ray/di": "~2.0",
+        "laminas/laminas-permissions-acl": "~2.5"
     },
     "autoload":{
         "psr-4":{

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
     },
     "autoload-dev":{
         "psr-4":{
-            "Ray\\RoleModule\\": "tests/",
-            "Ray\\RoleModule\\": "tests/Fake"
+            "Ray\\RoleModule\\": ["tests/", "tests/Fake"]
         }
     },
     "minimum-stability": "dev",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <phpunit bootstrap="tests/bootstrap.php">
     <testsuites>
-        <testsuite>
+        <testsuite name="Ray.RoleModule">
             <directory suffix="Test.php">tests</directory>
         </testsuite>
     </testsuites>

--- a/src/RequiredRolesInterceptor.php
+++ b/src/RequiredRolesInterceptor.php
@@ -11,8 +11,8 @@ use Ray\Aop\MethodInterceptor;
 use Ray\Aop\MethodInvocation;
 use Ray\RoleModule\Annotation\RequiresRoles;
 use Ray\RoleModule\Exception\RequiredRolesException;
-use Zend\Permissions\Acl\AclInterface;
-use Zend\Permissions\Acl\Resource\GenericResource;
+use Laminas\Permissions\Acl\AclInterface;
+use Laminas\Permissions\Acl\Resource\GenericResource;
 
 class RequiredRolesInterceptor implements MethodInterceptor
 {

--- a/src/ZendAclModule.php
+++ b/src/ZendAclModule.php
@@ -11,7 +11,7 @@ use Doctrine\Common\Annotations\Reader;
 use Ray\RoleModule\Annotation\RequiresRoles;
 use Ray\Di\AbstractModule;
 use Ray\Di\Scope;
-use Zend\Permissions\Acl\AclInterface;
+use Laminas\Permissions\Acl\AclInterface;
 
 class ZendAclModule extends AbstractModule
 {

--- a/tests/RequiredRoleInterceptorTest.php
+++ b/tests/RequiredRoleInterceptorTest.php
@@ -3,19 +3,19 @@
 namespace Ray\RoleModule;
 
 use Doctrine\Common\Annotations\AnnotationReader;
-use Ray\Aop\Arguments;
+use PHPUnit\Framework\TestCase;
 use Ray\Aop\ReflectiveMethodInvocation;
 use Ray\RoleModule\Exception\RequiredRolesException;
 use Laminas\Permissions\Acl\Acl;
 use Laminas\Permissions\Acl\AclInterface;
 use Laminas\Permissions\Acl\Role\GenericRole;
 
-class RequiredRoleInterceptorTest extends \PHPUnit_Framework_TestCase
+class RequiredRoleInterceptorTest extends TestCase
 {
     private function factory($obj, $method, AclInterface $acl, RoleProviderInterface $roleProvider, $args = [])
     {
         $invocation = new ReflectiveMethodInvocation(
-            $obj, new \ReflectionMethod($obj, $method), new Arguments($args), [
+            $obj, $method, $args, [
                 new RequiredRolesInterceptor(new AnnotationReader, $acl, $roleProvider)
             ]
         );
@@ -40,7 +40,7 @@ class RequiredRoleInterceptorTest extends \PHPUnit_Framework_TestCase
 
     public function testMethodDeny()
     {
-        $this->setExpectedException(RequiredRolesException::class);
+        $this->expectException(RequiredRolesException::class);
         $acl = new Acl();
         $acl->addRole(new GenericRole('admin'));
         $acl->addRole(new GenericRole('guest'));

--- a/tests/RequiredRoleInterceptorTest.php
+++ b/tests/RequiredRoleInterceptorTest.php
@@ -6,9 +6,9 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Ray\Aop\Arguments;
 use Ray\Aop\ReflectiveMethodInvocation;
 use Ray\RoleModule\Exception\RequiredRolesException;
-use Zend\Permissions\Acl\Acl;
-use Zend\Permissions\Acl\AclInterface;
-use Zend\Permissions\Acl\Role\GenericRole;
+use Laminas\Permissions\Acl\Acl;
+use Laminas\Permissions\Acl\AclInterface;
+use Laminas\Permissions\Acl\Role\GenericRole;
 
 class RequiredRoleInterceptorTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/ZendAclModuleTest.php
+++ b/tests/ZendAclModuleTest.php
@@ -4,8 +4,8 @@ namespace Ray\RoleModule;
 
 use Ray\RoleModule\Exception\RequiredRolesException;
 use Ray\Di\Injector;
-use Zend\Permissions\Acl\Acl;
-use Zend\Permissions\Acl\Role\GenericRole;
+use Laminas\Permissions\Acl\Acl;
+use Laminas\Permissions\Acl\Role\GenericRole;
 
 class ZendAclModuleTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/ZendAclModuleTest.php
+++ b/tests/ZendAclModuleTest.php
@@ -2,12 +2,13 @@
 
 namespace Ray\RoleModule;
 
+use PHPUnit\Framework\TestCase;
 use Ray\RoleModule\Exception\RequiredRolesException;
 use Ray\Di\Injector;
 use Laminas\Permissions\Acl\Acl;
 use Laminas\Permissions\Acl\Role\GenericRole;
 
-class ZendAclModuleTest extends \PHPUnit_Framework_TestCase
+class ZendAclModuleTest extends TestCase
 {
     public function testModuleAllow()
     {
@@ -22,7 +23,7 @@ class ZendAclModuleTest extends \PHPUnit_Framework_TestCase
 
     public function testModuleDeny()
     {
-        $this->setExpectedException(RequiredRolesException::class);
+        $this->expectException(RequiredRolesException::class);
         $acl = new Acl();
         $acl->addRole(new GenericRole('admin'));
         $acl->addRole(new GenericRole('guest'));
@@ -34,7 +35,7 @@ class ZendAclModuleTest extends \PHPUnit_Framework_TestCase
 
     public function testModuleClassDeny()
     {
-        $this->setExpectedException(RequiredRolesException::class);
+        $this->expectException(RequiredRolesException::class);
         $acl = new Acl();
         $acl->addRole(new GenericRole('admin'));
         $acl->addRole(new GenericRole('guest'));


### PR DESCRIPTION
* PHP8.1環境でインストールできないため、 `zend-permissions-acl` を `laminas-permissions-acl` に移行